### PR TITLE
Parser change suggestions

### DIFF
--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -291,9 +291,6 @@
   <data name="MissingColonAfterArgumentLabel" xml:space="preserve">
     <value>Expected colon after argument name identifier "{0}" but found "{1}".</value>
   </data>
-  <data name="MissingArgumentAfterLabel" xml:space="preserve">
-    <value>Expected argument value after name identifier "{0}" but found "{1}".</value>
-  </data>
   <data name="DuplicateArgumentLabel" xml:space="preserve">
     <value>Found duplicate argument name label "{0}"</value>
   </data>

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -1468,9 +1468,9 @@ $c.Method(
 
             $pe.Errors[0].ErrorId | Should -Be DuplicateArgumentLabel
             $pe.Errors[0].Message | Should -Be 'Found duplicate argument name label "arg"'
-            $pe.ErrorRecord.InvocationInfo.PositionMessage | Should -Be (@(
+            $pe.ErrorRecord.InvocationInfo.PositionMessage | Should -BeExactly (@(
                     'At line:1 char:24'
-                    '+ $c.Method(arg: $value, arg: $value)'
+                    '+ $c.Method(Arg: $value, arg: $value)'
                     '+                        ~~~'
                 ) -join [Environment]::NewLine)
         }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -1353,7 +1353,7 @@ foo``u{2195}abc
         }
     }
 
-    Context "Method invocation argument labels" -Tag Jordan {
+    Context "Method invocation argument labels" {
         It "Parses single argument with label <Label.Trim()>" -TestCases @(
             @{ Label = "simple" }
             @{ Label = "_underscore" }
@@ -1431,31 +1431,6 @@ $c.Method(
             $actual[3].Expression.Value | Should -Be test
         }
 
-        It "Parses method invocation with label differing in case" {
-            $script = @'
-$c.Method(
-    label: $arg1,
-    Label: $arg2)
-'@
-
-            $errors = @()
-            $ast = [System.Management.Automation.Language.Parser]::ParseInput($script, [ref]$null, [ref]$errors)
-            $errors | Should -BeNullOrEmpty
-
-            $actual = $ast.EndBlock.Statements[0].PipelineElements[0].Expression.Arguments
-            $actual.Count | Should -Be 2
-
-            $actual[0] | Should -BeOfType ([System.Management.Automation.Language.LabeledExpressionAst])
-            $actual[0].Label | Should -BeExactly label
-            $actual[0].Expression | Should -BeOfType ([System.Management.Automation.Language.VariableExpressionAst])
-            $actual[0].Expression.VariablePath | Should -Be arg1
-
-            $actual[1] | Should -BeOfType ([System.Management.Automation.Language.LabeledExpressionAst])
-            $actual[1].Label | Should -BeExactly Label
-            $actual[1].Expression | Should -BeOfType ([System.Management.Automation.Language.VariableExpressionAst])
-            $actual[1].Expression.VariablePath | Should -Be arg2
-        }
-
         It "Parses method invocation without label with string value" {
             $script = '$c.Method(''value'')'
 
@@ -1486,17 +1461,31 @@ $c.Method(
             $actual.VariablePath.UserPath | Should -Be 'provider:var'
         }
 
+        It "Fails to parse method invocation with label differing in case" {
+            $err = { ExecuteCommand '$c.Method(Arg: $value, arg: $value)' } | Should -Throw -ErrorId ParseException -PassThru
+            $pe = $err.Exception.InnerException
+            $pe | Should -BeOfType ([System.Management.Automation.ParseException])
+
+            $pe.Errors[0].ErrorId | Should -Be DuplicateArgumentLabel
+            $pe.Errors[0].Message | Should -Be 'Found duplicate argument name label "arg"'
+            $pe.ErrorRecord.InvocationInfo.PositionMessage | Should -Be (@(
+                    'At line:1 char:24'
+                    '+ $c.Method(arg: $value, arg: $value)'
+                    '+                        ~~~'
+                ) -join [Environment]::NewLine)
+        }
+
         It "Fails to parse label with newline after separator" {
             $err = { ExecuteCommand "`$c.Method(label:`n'value')" } | Should -Throw -ErrorId ParseException -PassThru
             $pe = $err.Exception.InnerException
             $pe | Should -BeOfType ([System.Management.Automation.ParseException])
 
-            $pe.Errors[0].ErrorId | Should -Be MissingArgumentAfterLabel
-            $pe.Errors[0].Message | Should -Be 'Expected argument value after name identifier "label" but found "\u000a".'
+            $pe.Errors[0].ErrorId | Should -Be MissingExpressionAfterToken
+            $pe.Errors[0].Message | Should -Be "Missing expression after ':'."
             $pe.ErrorRecord.InvocationInfo.PositionMessage | Should -Be (@(
-                    'At line:1 char:16'
+                    'At line:1 char:17'
                     '+ $c.Method(label:'
-                    '+                ~'
+                    '+                 ~'
                 ) -join [Environment]::NewLine)
         }
 
@@ -1655,7 +1644,7 @@ $c.Method(
             $pe.ErrorRecord.InvocationInfo.PositionMessage | Should -Be (@(
                     'At line:1 char:24'
                     '+ $c.Method(arg: $value, arg: $value)'
-                    '+                        ~~~~~~~~~~~'
+                    '+                        ~~~'
                 ) -join [Environment]::NewLine)
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Moved the duplicate and positional argument checks to SemanticChecks.
Justification: This follows the existing conventions and improves the error recovery in the parsing.

Added tracking for successfully parsed label/colon tokens so the Ast extent for an incomplete statement can be more accurate.
Justification: This will make it easier to write the tab completion code due to the way the ast is analyzed there.

Replaced the "MissingArgumentAfterLabel" error with "MissingExpressionAfterToken" when there's no valid argument after a colon.
Justification: This seems more consistent with the normal error handling in the parser but this is obviously very subjective so feel free to discard this and similar suggestions.

Adjusted the error position for duplicate labels so the error is under the label rather than the label + expression.
Justification: Seems more accurate to me.

Adjusted the error position when there's a missing expression after the colon so it's after the colon instead of on the colon.
Justification: This matches the error reporting in other scenarios, like when there's a trailing comma.

Made the duplicate label check case insensitive.
Justification: Since you made it case insensitive in the binder there's no point in making it sensitive in the parser.

Removed a "Jordan" test Tag from the tests.
Justification: I assume you forgot to remove it yourself.
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
    - [ ] None
    - **OR**
    - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.3/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
        - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
- **Tooling**
    - [ ] I have considered the user experience from a tooling perspective and don't believe tooling will be impacted.
    - **OR**
    - [ ] I have considered the user experience from a tooling perspective and opened an issue in the relevant tool repository. This may include:
        - [ ] Impact on [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) which is used in the [PowerShell extension](https://github.com/PowerShell/vscode-powershell) for VSCode
        (which runs in a different PS Host).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on Completions (both in the console and in editors) - one of PowerShell's most powerful features.
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) (which provides linting & formatting in the editor extensions).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
        - [ ] Impact on [EditorSyntax](https://github.com/PowerShell/EditorSyntax) (which provides syntax highlighting with in VSCode, GitHub, and many other editors).
            - [ ] Issue filed: <!-- Number/link of that issue here -->
